### PR TITLE
Add more explicit license notices

### DIFF
--- a/KRONKY_LICENSE.md
+++ b/KRONKY_LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Ethelo.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2019, Mirego
+Copyright (c) 2019, Mirego
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Thank you [Ethelo](http://ethelo.com/) for the awesome library!
 
 AbsintheErrorPayload is © 2019 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/absinthe_error_payload/blob/master/LICENSE.md) file.
 
+As mentionned above, AbsintheErrorPayload is based on [Kronky](https://github.com/Ethelo/kronky) which is licensed under the [MIT license](http://opensource.org/licenses/MIT). See the [`KRONKY_LICENSE.md`](https://github.com/mirego/absinthe_error_payload/blob/master/KRONKY_LICENSE.md) file.
+
 The flask logo is based on [this lovely icon by Danil Polshin](https://thenounproject.com/term/flask/1428207), from The Noun Project. Used under a [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/) license.
 
 ## About Mirego

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule AbsintheErrorPayload.Mixfile do
   defp package do
     [
       maintainers: ["Simon Prévost"],
-      licenses: ["MIT"],
+      licenses: ["BSD-3"],
       links: %{
         "GitHub" => "https://github.com/mirego/absinthe_error_payload"
       }


### PR DESCRIPTION
Since Kronky is licensed under the MIT license, it is mandatory to include the original license when releasing it as our own project under the BSD-3 license.

As stated in the MIT license (emphasis mine):

> […] the rights to use, copy, modify, merge, publish, distribute, **sublicense**, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
> 
> **The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.**

So we’re now very clear about that 😄 