### PR TITLE
Map :options Keyword List into a Map

### DIFF
--- a/lib/absinthe_error_payload/changeset_parser.ex
+++ b/lib/absinthe_error_payload/changeset_parser.ex
@@ -91,7 +91,7 @@ defmodule AbsintheErrorPayload.ChangesetParser do
       key: field,
       template: message,
       message: interpolate_message({message, opts}),
-      options: tidy_opts(opts)
+      options: opts |> tidy_opts() |> Enum.into(%{})
     }
   end
 

--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -390,7 +390,7 @@ defmodule AbsintheErrorPayload.Payload do
       field: nil,
       template: message,
       message: message,
-      options: []
+      options: %{}
     }
   end
 end

--- a/lib/absinthe_error_payload/validation_message.ex
+++ b/lib/absinthe_error_payload/validation_message.ex
@@ -38,5 +38,5 @@ defmodule AbsintheErrorPayload.ValidationMessage do
   Deprecated, use :field instead
   """
   @enforce_keys [:code]
-  defstruct field: nil, key: nil, code: nil, options: [], template: "is invalid", message: "is invalid"
+  defstruct field: nil, key: nil, code: nil, options: %{}, template: "is invalid", message: "is invalid"
 end

--- a/test/changeset_parser_custom_field_constructor_test.exs
+++ b/test/changeset_parser_custom_field_constructor_test.exs
@@ -74,6 +74,7 @@ defmodule AbsintheErrorPayload.ChangesetParserCustomFieldConstructorTest do
 
       assert %ValidationMessage{} = message
       assert message.field == "@root›title"
+      assert %{} == message.options
     end
   end
 

--- a/test/changeset_parser_test.exs
+++ b/test/changeset_parser_test.exs
@@ -193,7 +193,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == "foobar"
       assert message.key == :title
       assert message.field == :title
-      assert message.options == [illegal: "foobar"]
+      assert message.options == %{illegal: "foobar"}
       assert message.message =~ ~r/foobar/
       assert message.template =~ ~r/%{illegal}/
     end
@@ -210,7 +210,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == "foobar"
       assert message.key == :title
       assert message.field == :title
-      assert message.options == [illegal: "foobar"]
+      assert message.options == %{illegal: "foobar"}
       assert message.message =~ ~r/foobar/
       assert message.template =~ ~r/%{illegal}/
     end
@@ -225,7 +225,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :unknown
       assert message.key == :title
       assert message.field == :title
-      assert message.options == [illegal: "foobar"]
+      assert message.options == %{illegal: "foobar"}
       assert message.message =~ ~r/foobar/
       assert message.template =~ ~r/%{illegal}/
     end
@@ -240,7 +240,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :format
       assert message.key == :title
       assert message.field == :title
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -255,7 +255,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :inclusion
       assert message.key == :title
       assert message.field == :title
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -270,7 +270,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :subset
       assert message.key == :topics
       assert message.field == :topics
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -285,7 +285,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :exclusion
       assert message.key == :title
       assert message.field == :title
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -300,7 +300,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :min
       assert message.key == :title
       assert message.field == :title
-      assert message.options == [count: 2, kind: :min, type: :string]
+      assert message.options == %{count: 2, kind: :min, type: :string}
       assert message.message =~ ~r/2/
       assert message.template =~ ~r/%{count}/
     end
@@ -315,7 +315,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :max
       assert message.key == :title
       assert message.field == :title
-      assert message.options == [count: 3, kind: :max, type: :string]
+      assert message.options == %{count: 3, kind: :max, type: :string}
       assert message.message =~ ~r/3/
       assert message.template =~ ~r/%{count}/
     end
@@ -330,7 +330,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :length
       assert message.key == :title
       assert message.field == :title
-      assert message.options == [count: 7, kind: :is, type: :string]
+      assert message.options == %{count: 7, kind: :is, type: :string}
       assert message.message =~ ~r/7/
       assert message.template =~ ~r/%{count}/
     end
@@ -345,7 +345,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :greater_than
       assert message.key == :upvotes
       assert message.field == :upvotes
-      assert message.options == [kind: :greater_than, number: 10]
+      assert message.options == %{kind: :greater_than, number: 10}
       assert message.message =~ ~r/10/
       assert message.template =~ ~r/%{number}/
     end
@@ -360,7 +360,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :greater_than_or_equal_to
       assert message.key == :upvotes
       assert message.field == :upvotes
-      assert message.options == [kind: :greater_than_or_equal_to, number: 10]
+      assert message.options == %{kind: :greater_than_or_equal_to, number: 10}
       assert message.message =~ ~r/10/
       assert message.template =~ ~r/%{number}/
     end
@@ -375,7 +375,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :less_than
       assert message.key == :upvotes
       assert message.field == :upvotes
-      assert message.options == [kind: :less_than, number: 1]
+      assert message.options == %{kind: :less_than, number: 1}
       assert message.message =~ ~r/1/
       assert message.template =~ ~r/%{number}/
     end
@@ -390,7 +390,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :less_than_or_equal_to
       assert message.key == :upvotes
       assert message.field == :upvotes
-      assert message.options == [kind: :less_than_or_equal_to, number: 1]
+      assert message.options == %{kind: :less_than_or_equal_to, number: 1}
       assert message.message =~ ~r/1/
       assert message.template =~ ~r/%{number}/
     end
@@ -405,7 +405,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :equal_to
       assert message.key == :upvotes
       assert message.field == :upvotes
-      assert message.options == [kind: :equal_to, number: 1]
+      assert message.options == %{kind: :equal_to, number: 1}
       assert message.message =~ ~r/1/
       assert message.template =~ ~r/%{number}/
     end
@@ -420,7 +420,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :confirmation
       assert message.key == :title_confirmation
       assert message.field == :title_confirmation
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -435,7 +435,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :acceptance
       assert message.key == :terms_of_service
       assert message.field == :terms_of_service
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -450,7 +450,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :required
       assert message.key == :title
       assert message.field == :title
-      assert message.options == []
+      assert message.options == %{}
       assert message.message != ""
       assert message.template != ""
     end
@@ -465,7 +465,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.code == :cast
       assert message.key == :body
       assert message.field == :body
-      assert message.options == [type: :string]
+      assert message.options == %{type: :string}
       assert message.message != ""
       assert message.template != ""
     end


### PR DESCRIPTION
Currently :options field is a Keyword List, which is not encode-able by some JSON encoders (ie. Jason). Converting Keyword List into a Map would make it serialisable and readable from client-side.