### PR TITLE
Fix the build_payload

### DIFF
--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -193,9 +193,14 @@ defmodule AbsintheErrorPayload.Payload do
   in your resolver instead. See `convert_to_payload/1`, `success_payload/1` and `error_payload/1` for examples.
 
   """
+  def build_payload(%{errors: [%Ecto.Changeset{} = errors]} = resolution, _config) do
+    result = convert_to_payload(errors)
+    %{resolution | value: result, errors: []}
+  end
+
   def build_payload(%{value: value, errors: []} = resolution, _config) do
     result = convert_to_payload(value)
-    Absinthe.Resolution.put_result(resolution, {:ok, result})
+    %{resolution | value: result, errors: []}
   end
 
   @doc """
@@ -210,9 +215,10 @@ defmodule AbsintheErrorPayload.Payload do
   ["This is an error", "This is another error"]
   ```
   """
+
   def build_payload(%{errors: errors} = resolution, _config) do
     result = convert_to_payload({:error, errors})
-    Absinthe.Resolution.put_result(resolution, {:ok, result})
+    %{resolution | value: result, errors: []}
   end
 
   @doc """

--- a/test/payload_test.exs
+++ b/test/payload_test.exs
@@ -43,7 +43,7 @@ defmodule AbsintheErrorPayload.PayloadTest do
   end
 
   def assert_error_payload(messages, result) do
-    assert %{value: value} = result
+    assert %{value: value, errors: []} = result
 
     expected = payload(false, messages)
 


### PR DESCRIPTION
After Absinthe 1.4, only update the value is not enough, we also need to update the errors.