### PR TITLE
Add handling for atoms as error messages

### DIFF
--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -280,7 +280,6 @@ defmodule AbsintheErrorPayload.Payload do
     |> error_payload()
   end
 
-  å
   def convert_to_payload(value), do: success_payload(value)
 
   @doc """

--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -184,6 +184,7 @@ defmodule AbsintheErrorPayload.Payload do
   {:error, %ValidationMessage{}}
   {:error, [%ValidationMessage{},%ValidationMessage{}]}
   {:error, "This is an error"}
+  {:error, :error_atom}
   {:error, ["This is an error", "This is another error"]}
   ```
 
@@ -201,12 +202,13 @@ defmodule AbsintheErrorPayload.Payload do
   @doc """
   Convert resolution errors to a mutation payload
 
-  The build payload middleware will accept lists of `AbsintheErrorPayload.ValidationMessage` or string errors.
+  The build payload middleware will accept lists of `AbsintheErrorPayload.ValidationMessage`, atom, or string errors.
 
   Valid formats are:
   ```
   [%ValidationMessage{},%ValidationMessage{}]
   "This is an error"
+  :error_atom
   ["This is an error", "This is another error"]
   ```
   """
@@ -230,6 +232,7 @@ defmodule AbsintheErrorPayload.Payload do
   {:error, %ValidationMessage{}}
   {:error, [%ValidationMessage{},%ValidationMessage{}]}
   {:error, "This is an error"}
+  {:error, :error_atom}
   {:error, ["This is an error", "This is another error"]}
   ```
 
@@ -267,6 +270,8 @@ defmodule AbsintheErrorPayload.Payload do
     |> error_payload()
   end
 
+  def convert_to_payload({:error, message}) when is_atom(message), do: convert_to_payload({:error, "#{message}"})
+
   def convert_to_payload({:error, list}) when is_list(list), do: error_payload(list)
 
   def convert_to_payload(%Ecto.Changeset{valid?: false} = changeset) do
@@ -275,6 +280,7 @@ defmodule AbsintheErrorPayload.Payload do
     |> error_payload()
   end
 
+  å
   def convert_to_payload(value), do: success_payload(value)
 
   @doc """
@@ -347,6 +353,10 @@ defmodule AbsintheErrorPayload.Payload do
 
   defp prepare_message(message) when is_binary(message) do
     generic_validation_message(message)
+  end
+
+  defp prepare_message(message) when is_atom(message) do
+    generic_validation_message("#{message}")
   end
 
   defp prepare_message(message) do

--- a/test/payload_test.exs
+++ b/test/payload_test.exs
@@ -95,6 +95,17 @@ defmodule AbsintheErrorPayload.PayloadTest do
       assert expected == value
     end
 
+    test "error tuple with an atom message" do
+      resolution = resolution({:error, :an_error})
+
+      result = build_payload(resolution, nil)
+
+      assert %{value: value} = result
+
+      expected = payload(false, [%ValidationMessage{code: :unknown, field: nil, key: nil, message: "an_error", options: [], template: "an_error"}])
+      assert expected == value
+    end
+
     test "error changeset" do
       changeset =
         {%{}, %{title: :string, title_lang: :string}}
@@ -156,6 +167,14 @@ defmodule AbsintheErrorPayload.PayloadTest do
       result = build_payload(resolution, nil)
 
       message = %ValidationMessage{code: :unknown, message: "an error", template: "an error"}
+      assert_error_payload([message], result)
+    end
+
+    test "error from resolution, atom message" do
+      resolution = resolution_error([:an_error])
+      result = build_payload(resolution, nil)
+
+      message = %ValidationMessage{code: :unknown, message: "an_error", template: "an_error"}
       assert_error_payload([message], result)
     end
 


### PR DESCRIPTION
In my experience, it's not uncommon for error tuples like `{:error, :unauthorized}` to be passed around in an application and since in a lot of cases that is a sufficiently explanatory message for the error, having this library take care of intercepting and stringifying those errors would be a nice-to-have that would be fairly easy to implement