### PR TITLE
Make the test helpers compatible with nested fields

### DIFF
--- a/lib/absinthe_error_payload/test_helper.ex
+++ b/lib/absinthe_error_payload/test_helper.ex
@@ -127,6 +127,13 @@ defmodule AbsintheErrorPayload.TestHelper do
     assert {field, expected} == {field, response}
   end
 
+  defp assert_values_match({_field, %{} = sub_fields, expected, response}) do
+    sub_fields
+    |> Enum.to_list()
+    |> Enum.map(fn field_tuple -> value_tuple(field_tuple, expected, response) end)
+    |> Enum.each(&assert_values_match/1)
+  end
+
   defp assert_values_match({field, _type, expected, response}) do
     assert {field, expected} == {field, response}
   end

--- a/test/test_helper_test.exs
+++ b/test/test_helper_test.exs
@@ -24,6 +24,17 @@ defmodule AbsintheErrorPayload.TestHelperTest do
     }
   end
 
+  def nested_fields do
+    %{
+      root: :string,
+      single: %{
+        string: :string,
+        integer: :integer,
+        nillable: :nillable
+      }
+    }
+  end
+
   def input do
     %{
       date: @time,
@@ -48,6 +59,17 @@ defmodule AbsintheErrorPayload.TestHelperTest do
       float: nil,
       boolean1: nil,
       enum: nil
+    }
+  end
+
+  def nested_input do
+    %{
+      root: "root string",
+      single: %{
+        string: "single nested string",
+        integer: 1,
+        nillable: nil
+      }
     }
   end
 
@@ -78,6 +100,17 @@ defmodule AbsintheErrorPayload.TestHelperTest do
     }
   end
 
+  def nested_graphql do
+    %{
+      "root" => "root string",
+      "single" => %{
+        "string" => "single nested string",
+        "integer" => 1,
+        "nillable" => nil
+      }
+    }
+  end
+
   describe "assert_equivalent_graphql/3" do
     test "all types compare" do
       assert_equivalent_graphql(input(), graphql(), fields())
@@ -94,6 +127,10 @@ defmodule AbsintheErrorPayload.TestHelperTest do
         fields()
       )
     end
+
+    test "nested fields compare" do
+      assert_equivalent_graphql(nested_input(), nested_graphql(), nested_fields())
+    end
   end
 
   describe "assert_mutation_success/3" do
@@ -105,6 +142,16 @@ defmodule AbsintheErrorPayload.TestHelperTest do
       }
 
       assert_mutation_success(input(), mutation_response, fields())
+    end
+
+    test "matches result with nested fields" do
+      mutation_response = %{
+        "successful" => true,
+        "messages" => [],
+        "result" => nested_graphql()
+      }
+
+      assert_mutation_success(nested_input(), mutation_response, nested_fields())
     end
   end
 


### PR DESCRIPTION
Previously, a GraphQL document such as the below could not be tested if one of the values was null / `nil`. The library stringifies the expected response, coercing `nil` to `""`. The `assert_values_match` was not able to take into account the field being defined as `nillable` because it wasn't aware of the nesting. This led to the below mismatch:

```
  1) test assert_equivalent_graphql/3 nested fields compare (AbsintheErrorPayload.TestHelperTest)
     test/test_helper_test.exs:131
     Assertion with == failed
     code:  assert {field, expected} == {field, response}
     left:  {
              :single,
              %{
                "integer" => "1",
                "nillable" => "",
                "string" => "single nested string"
              }
            }
     right: {
              :single,
              %{
                "integer" => 1,
                "nillable" => nil,
                "string" => "single nested string"
              }
            }
     stacktrace:
       (elixir 1.11.3) lib/enum.ex:798: Enum."-each/2-lists^foreach/1-0-"/2
       test/test_helper_test.exs:132: (test)
```

This PR adds a new `assert_values_match` so that nested field definitions get recursively resolved.