### PR TITLE
Add support for Ecto.Enum

### DIFF
--- a/lib/absinthe_error_payload/changeset_parser.ex
+++ b/lib/absinthe_error_payload/changeset_parser.ex
@@ -139,6 +139,9 @@ defmodule AbsintheErrorPayload.ChangesetParser do
 
   defp interpolated_value_to_string(value) when is_list(value), do: Enum.join(value, ",")
 
+  defp interpolated_value_to_string({:parameterized, Ecto.Enum, %{on_load: mappings}}),
+    do: Map.values(mappings) |> Enum.join(",")
+
   defp interpolated_value_to_string(value), do: to_string(value)
 
   @doc """

--- a/lib/absinthe_error_payload/changeset_parser.ex
+++ b/lib/absinthe_error_payload/changeset_parser.ex
@@ -140,7 +140,7 @@ defmodule AbsintheErrorPayload.ChangesetParser do
   defp interpolated_value_to_string(value) when is_list(value), do: Enum.join(value, ",")
 
   defp interpolated_value_to_string({:parameterized, Ecto.Enum, %{on_load: mappings}}),
-    do: Map.values(mappings) |> Enum.join(",")
+    do: mappings |> Map.values() |> Enum.join(",")
 
   defp interpolated_value_to_string(value), do: to_string(value)
 

--- a/test/changeset_parser_test.exs
+++ b/test/changeset_parser_test.exs
@@ -43,6 +43,7 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       field(:topics, {:array, :string})
       field(:virtual, :string, virtual: true)
       field(:published_at, :naive_datetime)
+      field(:language, Ecto.Enum, values: [:en, :fr])
 
       belongs_to(:author, Author)
       has_many(:tags, Tag)
@@ -495,6 +496,22 @@ defmodule AbsintheErrorPayload.ChangesetParserTest do
       assert message.key == :body
       assert message.field == :body
       assert message.options == [%{key: :type, value: "string"}]
+      assert message.message != ""
+      assert message.template != ""
+    end
+
+    test "cast enum" do
+      params = %{"language" => :de}
+      struct = %Post{}
+
+      changeset = cast(struct, params, ~w(language)a)
+
+      assert [%ValidationMessage{} = message] = ChangesetParser.extract_messages(changeset)
+
+      assert message.code == :cast
+      assert message.key == :language
+      assert message.field == :language
+      assert message.options == [%{key: :type, value: "en,fr"}]
       assert message.message != ""
       assert message.template != ""
     end


### PR DESCRIPTION
## 📖 Description and reason

Currently, the changeset parser crashes when the changes contains an error produced by an `Ecto.Enum` field.

## 👷 Work done

Added support for `Ecto.Enum` errors in the changeset parser.

#### Additional notes

My goal was to avoid the crash. But I'm not 100% what the value of the `type` field should be.
