### PR TITLE
Fix list typings for payload and options

### DIFF
--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -110,9 +110,9 @@ defmodule AbsintheErrorPayload.Payload do
 
   ```elixir
   object :user_payload do
-    field :successful, non_null(:boolean), description: "Indicates if the mutation completed successfully or not. "
-    field :messages, list_of(:validation_message), description: "A list of failed validations. May be blank or null if mutation succeeded."
-    field :result, :user, description: "The object created/updated/deleted by the mutation"
+    field :successful, non_null(:boolean), description: "..."
+    field :messages, non_null(list_of(non_null(:validation_message))), description: "..."
+    field :result, :user, description: "..."
   end
   ```
 
@@ -122,7 +122,7 @@ defmodule AbsintheErrorPayload.Payload do
     quote location: :keep do
       object unquote(payload_name) do
         field(:successful, non_null(:boolean), description: "Indicates if the mutation completed successfully or not. ")
-        field(:messages, list_of(:validation_message), description: "A list of failed validations. May be blank or null if mutation succeeded.")
+        field(:messages, non_null(list_of(non_null(:validation_message))), description: "A list of failed validations. Empty if mutation succeeded.")
         field(:result, unquote(result_object_name), description: "The object created/updated/deleted by the mutation. May be null if mutation failed.")
       end
     end
@@ -202,19 +202,6 @@ defmodule AbsintheErrorPayload.Payload do
     result = convert_to_payload(value)
     %{resolution | value: result, errors: []}
   end
-
-  @doc """
-  Convert resolution errors to a mutation payload
-
-  The build payload middleware will accept lists of `AbsintheErrorPayload.ValidationMessage` or string errors.
-
-  Valid formats are:
-  ```
-  [%ValidationMessage{},%ValidationMessage{}]
-  "This is an error"
-  ["This is an error", "This is another error"]
-  ```
-  """
 
   def build_payload(%{errors: errors} = resolution, _config) do
     result = convert_to_payload({:error, errors})

--- a/lib/absinthe_error_payload/validation_message_types.ex
+++ b/lib/absinthe_error_payload/validation_message_types.ex
@@ -32,7 +32,7 @@ defmodule AbsintheErrorPayload.ValidationMessageTypes do
     field :message, :string, description: "..."
     field :code, non_null(:string), description: "..."
     field :template, :string, description: "..."
-    field :options, list_of(:validation_option), description: "..."
+    field :options, non_null(list_of(non_null(:validation_option))), description: "..."
   end
   ```
 
@@ -103,6 +103,6 @@ defmodule AbsintheErrorPayload.ValidationMessageTypes do
     field(:template, :string, description: @descs.template)
 
     @desc "A list of substitutions to be applied to a validation message template"
-    field(:options, list_of(:validation_option), description: @descs.option_list)
+    field(:options, non_null(list_of(non_null(:validation_option))), description: @descs.option_list)
   end
 end


### PR DESCRIPTION
## 📖 Description and reason

Since we initialize the struct with an empty list, we should type the GraphQL field accordingly.

## 🦀 Dispatch

`#dispatch/elixir`
