### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Thank you [Ethelo](http://ethelo.com/) for the awesome library!
 
 AbsintheErrorPayload is © 2019 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/absinthe_error_payload/blob/master/LICENSE.md) file.
 
-As mentionned above, AbsintheErrorPayload is based on [Kronky](https://github.com/Ethelo/kronky) which is licensed under the [MIT license](http://opensource.org/licenses/MIT). See the [`KRONKY_LICENSE.md`](https://github.com/mirego/absinthe_error_payload/blob/master/KRONKY_LICENSE.md) file.
+As mentioned above, AbsintheErrorPayload is based on [Kronky](https://github.com/Ethelo/kronky) which is licensed under the [MIT license](http://opensource.org/licenses/MIT). See the [`KRONKY_LICENSE.md`](https://github.com/mirego/absinthe_error_payload/blob/master/KRONKY_LICENSE.md) file.
 
 The flask logo is based on [this lovely icon by Danil Polshin](https://thenounproject.com/term/flask/1428207), from The Noun Project. Used under a [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/) license.
 

--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -6,7 +6,7 @@ defmodule AbsintheErrorPayload.Payload do
 
   - `successful` - Indicates if the mutation completed successfully or not. Boolean.
   - `messages` - a list of validation errors. Always empty on success
-  - `result` - the data object that was created/updated/deleted on success. Always nil when unsuccesful
+  - `result` - the data object that was created/updated/deleted on success. Always nil when unsuccessful
 
 
   ## Usage
@@ -131,7 +131,7 @@ defmodule AbsintheErrorPayload.Payload do
   @doc ~S'''
   Convert a resolution value to a mutation payload
 
-  To be used as middleware by Absinthe.Graphql. It should be placed immediatly after the resolver.
+  To be used as middleware by Absinthe.Graphql. It should be placed immediately after the resolver.
 
   The middleware will automatically transform an invalid changeset into validation errors.
 

--- a/lib/absinthe_error_payload/test_helper.ex
+++ b/lib/absinthe_error_payload/test_helper.ex
@@ -138,7 +138,7 @@ defmodule AbsintheErrorPayload.TestHelper do
   of the data. This performs some simple transforms to properly compare values, including:
 
   - camelCasing field names
-  - coverting all non-int values to strings, including converting `false` to `"false"`
+  - converting all non-int values to strings, including converting `false` to `"false"`
   - uppercasing enum field responses
   - parsing date types as ISO Extended format strings
 
@@ -164,10 +164,10 @@ defmodule AbsintheErrorPayload.TestHelper do
 
   """
   def assert_equivalent_graphql(expected, response, %{} = fields) when is_list(expected) do
-    assert is_list(response), "expected a list, recieved #{inspect(response)}"
+    assert is_list(response), "expected a list, received #{inspect(response)}"
 
     assert Enum.count(expected) == Enum.count(response),
-           "Expected #{Enum.count(expected)} items, recieved #{inspect(response)}"
+           "Expected #{Enum.count(expected)} items, received #{inspect(response)}"
 
     for {e, m} <- Enum.zip(expected, response) do
       assert_equivalent_graphql(e, m, fields)

--- a/lib/absinthe_error_payload/validation_message.ex
+++ b/lib/absinthe_error_payload/validation_message.ex
@@ -22,7 +22,7 @@ defmodule AbsintheErrorPayload.ValidationMessage do
   Example: `"Username must be at least 10 characters"`
 
   ### :template
-  A template used to generate the error message, with placeholders for option substiution.
+  A template used to generate the error message, with placeholders for option substitution.
 
   Example: `"Username must be at least %{count} characters"`
 

--- a/lib/absinthe_error_payload/validation_message_types.ex
+++ b/lib/absinthe_error_payload/validation_message_types.ex
@@ -36,12 +36,12 @@ defmodule AbsintheErrorPayload.ValidationMessageTypes do
   end
   ```
 
-  Actual descriptions have been ommited for brevity - check the github repo to see them.
+  Actual descriptions have been omitted for brevity - check the github repo to see them.
   """
   use Absinthe.Schema.Notation
 
   object(:validation_option) do
-    @desc "The name of a variable to be subsituted in a validation message template"
+    @desc "The name of a variable to be substituted in a validation message template"
     field(:key, non_null(:string), description: @descs.option_key)
 
     @desc "The value of a variable to be substituted in a validation message template"
@@ -93,7 +93,7 @@ defmodule AbsintheErrorPayload.ValidationMessageTypes do
     field(:code, non_null(:string), description: @descs.code)
 
     @desc """
-    A template used to generate the error message, with placeholders for option substiution.
+    A template used to generate the error message, with placeholders for option substitution.
 
     Example: `Username must be at least {count} characters`
 


### PR DESCRIPTION
Found via `codespell -S deps .`
