### PR TITLE
Fix Ecto.Enum support for Ecto 3.12

### DIFF
--- a/lib/absinthe_error_payload/changeset_parser.ex
+++ b/lib/absinthe_error_payload/changeset_parser.ex
@@ -139,7 +139,12 @@ defmodule AbsintheErrorPayload.ChangesetParser do
 
   defp interpolated_value_to_string(value) when is_list(value), do: Enum.join(value, ",")
 
+  # Ecto < 3.12
   defp interpolated_value_to_string({:parameterized, Ecto.Enum, %{on_load: mappings}}),
+    do: mappings |> Map.values() |> Enum.join(",")
+
+  # Ecto >= 3.12
+  defp interpolated_value_to_string({:parameterized, {Ecto.Enum, %{on_load: mappings}}}),
     do: mappings |> Map.values() |> Enum.join(",")
 
   defp interpolated_value_to_string(value), do: to_string(value)


### PR DESCRIPTION
## 📖 Description and reason

Ecto 3.12 changes the format of parameterized types.

## 👷 Work done

I added support for Ecto 3.12, while keeping support for Ecto < 3.12.

I'm not gonna put more work into this because I have a feeling this repo is not maintained anymore. Let me know if anything is needed ;)